### PR TITLE
fix(screen): 修复长命令换行后循环覆盖bug

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -101,6 +101,11 @@ func (s *Screen) parseC0Sequence(code rune) {
 			\r
 		*/
 		s.Cursor.X = 0
+		if s.Cursor.Y > len(s.Rows) {
+			s.Rows = append(s.Rows, &Row{
+				dataRune: make([]rune, 0, 1024),
+			})
+		}
 	case 0x0a:
 		/*
 			\n


### PR DESCRIPTION
最近做一个web terminal项目，要求有黑白名单控制，使用了jumpserver的思路，使用了贵代码，测试发现存在长命令换行后循环覆盖的bug。
我前端使用的是xterm，换行时后端返回'0x20'（空格）和'0x0d'（回车）两个字符，所以在解析‘0x0d’时，需要对鼠标的Y轴进行处理，另外解析后的命令数组除了最后一个，前面的每个命令最后会多一个空格。